### PR TITLE
Update recipe to 1.12.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "mcp" %}
-{% set version = "1.9.2" %}
+{% set version = "1.12.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/mcp-{{ version }}.tar.gz
-  sha256: 3c7651c053d635fd235990a12e84509fe32780cd359a5bbef352e20d4d963c05
+  sha256: a4b7c742c50ce6ed6d6a6c096cca0e3893f5aecc89a59ed06d47c4e6ba41edcc
 
 build:
   skip: true  # [py<310]
@@ -26,7 +26,7 @@ requirements:
     - anyio >=4.5
     - httpx >=0.27
     - httpx-sse >=0.4
-    - pydantic >=2.7.2,<3.0.0
+    - pydantic >=2.8.0,<3.0.0
     - pydantic-settings >=2.5.2
     # - python-dotenv >=1.0.0
     - python-multipart >=0.0.9
@@ -35,6 +35,7 @@ requirements:
     - starlette >=0.27
     # - typer >=0.12.4
     - uvicorn >=0.23.1
+    - jsonschema >=4.20.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,6 +36,7 @@ requirements:
     # - typer >=0.12.4
     - uvicorn >=0.23.1
     - jsonschema >=4.20.0
+    - pywin32  # [win]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,6 +37,7 @@ requirements:
     - uvicorn >=0.23.1
     - jsonschema >=4.20.0
     - pywin32  # [win]
+    - pywin32-ctypes  # [win]
 
 test:
   imports:


### PR DESCRIPTION
### Links

- Upstream repo: https://github.com/modelcontextprotocol/python-sdk/tree/v1.12.2

### Explanation of changes:

- Updated version and SHA
- Bumped minimal pydantic version (https://github.com/modelcontextprotocol/python-sdk/pull/993)
- Added jsonschema (https://github.com/modelcontextprotocol/python-sdk/pull/1005)
- Added pywin32 on Windows (https://github.com/modelcontextprotocol/python-sdk/pull/1078)
