### PR TITLE
[PKG-12457] 1.26.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,20 +24,20 @@ requirements:
   run:
     - python
     - anyio >=4.5
-    - httpx >=0.27
+    - httpx >=0.27.1
     - httpx-sse >=0.4
-    - pydantic >=2.8.0,<3.0.0
+    - pydantic >=2.11.0,<3.0.0
     - pydantic-settings >=2.5.2
+    - pyjwt >=2.10.1
     - python-multipart >=0.0.9
     - rich >=13.9.4
     - sse-starlette >=1.6.1
     - starlette >=0.27
-    - uvicorn >=0.23.1    # [not emscripten]
+    - uvicorn >=0.31.1    # [not emscripten]
     - jsonschema >=4.20.0
     - pywin32 >=310  # [win]
   run_constrained:
     - python-dotenv >=1.0.0
-    - rich >=13.9.4
     - websockets >=15.0.1
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "mcp" %}
-{% set version = "1.12.1" %}
+{% set version = "1.26.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/mcp-{{ version }}.tar.gz
-  sha256: d1d0bdeb09e4b17c1a72b356248bf3baf75ab10db7008ef865c4afbeb0eb810e
+  sha256: db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66
 
 build:
   skip: true  # [py<310]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,7 +45,7 @@ test:
     - mcp
   commands:
     - pip check
-    # - mcp --help
+    - mcp --help
   requires:
     - pip
     - typer

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,11 +36,11 @@ requirements:
     - uvicorn >=0.31.1    # [not emscripten]
     - jsonschema >=4.20.0
     - pywin32 >=310  # [win]
-    # cli
-    - typer >=0.16.0
-    - python-dotenv >=1.0.0
   run_constrained:
     - websockets >=15.0.1
+    # cli
+    - python-dotenv >=1.0.0
+    - typer >=0.16.0
 
 test:
   imports:
@@ -50,6 +50,8 @@ test:
     - mcp --help
   requires:
     - pip
+    - python-dotenv
+    - typer
 
 about:
   home: https://modelcontextprotocol.io/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,8 +36,10 @@ requirements:
     - uvicorn >=0.31.1    # [not emscripten]
     - jsonschema >=4.20.0
     - pywin32 >=310  # [win]
-  run_constrained:
+    # cli
+    - typer >=0.16.0
     - python-dotenv >=1.0.0
+  run_constrained:
     - websockets >=15.0.1
 
 test:
@@ -48,7 +50,6 @@ test:
     - mcp --help
   requires:
     - pip
-    - typer
 
 about:
   home: https://modelcontextprotocol.io/


### PR DESCRIPTION
mcp 1.26.0

**Destination channel:** defaults

### Links

- [PKG-12457]
- [Upstream repository](https://github.com/modelcontextprotocol/python-sdk)

### Explanation of changes:

- Minor dependency updates


[PKG-12457]: https://anaconda.atlassian.net/browse/PKG-12457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ